### PR TITLE
fixed bug; enter redisplay to password input

### DIFF
--- a/bc/src/main/webapp/showUser.xhtml
+++ b/bc/src/main/webapp/showUser.xhtml
@@ -143,7 +143,7 @@
 						<p:selectBooleanCheckbox id="admin"
 							value="#{userAndShelvesHandler.rememberUser.admin}" />
 						<p:outputLabel value="#{msg.addUser_password}" for="password" />
-						<p:password id="password" match="repeatpassword"
+						<p:password id="password" match="repeatpassword" redisplay="true"
 							promptLabel="#{msg.addUser_msg_passwordPrompt}"
 							weakLabel="#{msg.addUser_msg_passwordWeak}"
 							goodLabel="#{msg.addUser_msg_passwordGood}"
@@ -152,7 +152,7 @@
 							value="#{userAndShelvesHandler.rememberUser.password}" />
 						<p:outputLabel value="#{msg.addUser_repeatPassword}"
 							for="repeatpassword" />
-						<p:password id="repeatpassword" required="true"
+						<p:password id="repeatpassword" required="true" redisplay="true"
 							value="#{userAndShelvesHandler.rememberUser.password}" />
 						<f:facet name="footer">
 							<p:commandButton


### PR DESCRIPTION
if you edit a user in the userAdministration you had to enter a password to save the user; now the password will be in the passwordfield; you save the same password again